### PR TITLE
schema: make "Emoji.animated" nullable

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -133,6 +133,7 @@ components:
           description: "The id of the reaction (if custom); null if a built-in emoji"
         animated:
           type: boolean
+          nullable: true
           description: whether or not the emoji is animated
         name:
           type: string


### PR DESCRIPTION
@nilslice noticed this while working on a Rust plugin – Discord doesn't _always_ set `animated`. This should fix the problem for plugins going forward!