### PR TITLE
fix: make `IncomingEvent.guild` and `IncomingEvent.channel` nullable

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -66,10 +66,12 @@ components:
         channel:
           type: string
           description: The channel the message was received in
+          nullable: true
 
         guild:
           type: string
           description: The guild the message was received in
+          nullable: true
 
     OutgoingRequest:
       description: An HTTP request


### PR DESCRIPTION
In addition to the `Emoji.animated` field, I had to make these nullable to get my Rust plugin to work.